### PR TITLE
Use = instead of == when running as sh

### DIFF
--- a/plugins/lfetool/templates/lfetool.tmpl
+++ b/plugins/lfetool/templates/lfetool.tmpl
@@ -1252,7 +1252,7 @@ run () {
             # Not sure why; perhaps someone with serious Bash skills can
             # explain what's going on and provide a better way of doing this
             # than the work around below.
-            if [ "$0" == "bash" ]; then
+            if [ "$0" = "bash" ]; then
                 echo
                 eval "$script -x" > /dev/null 2>&1
                 echo "In order to run the LFE REPL from this script, it has to"


### PR DESCRIPTION
= is the POSIX equality test in shell script; when running as `/bin/sh`, it's enough to cause problems.
