### PR TITLE
Change cover to title-page in presentation

### DIFF
--- a/plugins/presentation/templates/PROJECT-slides.lfe.tmpl
+++ b/plugins/presentation/templates/PROJECT-slides.lfe.tmpl
@@ -4,7 +4,7 @@
 (include-lib "deps/reveal-js/include/macros.lfe")
 
 (defun introduction (arg-data)
-  (cover
+  (title-page
     (h1 '"LFE-Reveal-JS")
     (h3 (list '"HTML Presentation Made" (em '" Ludicrously ") '"Robust"))
     (p (small '"(and absurdly hip)"))


### PR DESCRIPTION
reveal-js' macros changed to use title-page instead of cover.
