### PR TITLE
Update service start instructions.

### DIFF
--- a/doc/manual/new.rst
+++ b/doc/manual/new.rst
@@ -71,7 +71,7 @@ To run your new server:
 .. code:: shell
 
     $ cd my-new-service
-    $ make shell
+    $ make repl
 
 And then:
 


### PR DESCRIPTION
`make shell` currently starts an Erlang shell, where `make repl` starts an LFE shell.
